### PR TITLE
Ignore outdated events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
 jobs:
 
   build:
-    name: Build
+    name: Build and Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/cal_service.go
+++ b/cal_service.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
-	"google.golang.org/api/calendar/v3"
 	"os"
 	"time"
 
+	"google.golang.org/api/calendar/v3"
+
+	log "github.com/sirupsen/logrus"
 	"google.golang.org/api/option"
 )
 
@@ -25,8 +27,8 @@ const (
 
 type CalendarEvent struct {
 	Title   string
-	Start   string
-	End     string
+	Start   time.Time
+	End     time.Time
 	Creator string
 	Status  EventStatus
 }
@@ -126,18 +128,24 @@ func isEventUpdated(event *calendar.Event) bool {
 	return updated.Sub(created) >= time.Second
 }
 
-func parseEventStart(event *calendar.Event) string {
+func parseEventStart(event *calendar.Event) time.Time {
 	return parseEventTime(event.Start)
 }
 
-func parseEventEnd(event *calendar.Event) string {
+func parseEventEnd(event *calendar.Event) time.Time {
 	return parseEventTime(event.End)
 }
 
-func parseEventTime(eventDateTime *calendar.EventDateTime) string {
+func parseEventTime(eventDateTime *calendar.EventDateTime) time.Time {
 	if eventDateTime.Date != "" {
-		return eventDateTime.Date
+		return time.Time{}
 	}
 
-	return eventDateTime.DateTime
+	t, err := time.Parse(time.RFC3339, eventDateTime.DateTime)
+	if err != nil {
+		log.WithError(err).Error("error parsing event time")
+		return time.Time{}
+	}
+
+	return t
 }

--- a/cal_service.go
+++ b/cal_service.go
@@ -138,7 +138,12 @@ func parseEventEnd(event *calendar.Event) time.Time {
 
 func parseEventTime(eventDateTime *calendar.EventDateTime) time.Time {
 	if eventDateTime.Date != "" {
-		return time.Time{}
+		t, err := time.Parse(time.DateOnly, eventDateTime.Date)
+		if err != nil {
+			log.WithError(err).Error("error parsing event date")
+			return time.Time{}
+		}
+		return t
 	}
 
 	t, err := time.Parse(time.RFC3339, eventDateTime.DateTime)

--- a/cal_service_test.go
+++ b/cal_service_test.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/stretchr/testify/assert"
-	"google.golang.org/api/calendar/v3"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/api/calendar/v3"
 )
 
 func TestParseStatus(t *testing.T) {
@@ -73,8 +74,8 @@ func TestParseEventDates(t *testing.T) {
 	tests := []struct {
 		name          string
 		input         *calendar.Event
-		expectedStart string
-		expectedEnd   string
+		expectedStart time.Time
+		expectedEnd   time.Time
 	}{
 		{
 			name: "date and time",
@@ -86,8 +87,8 @@ func TestParseEventDates(t *testing.T) {
 					DateTime: "2024-06-12T21:00:00+03:00",
 				},
 			},
-			expectedStart: "2024-06-12T20:00:00+03:00",
-			expectedEnd:   "2024-06-12T21:00:00+03:00",
+			expectedStart: parseTimeNoError("2024-06-12T20:00:00+03:00"),
+			expectedEnd:   parseTimeNoError("2024-06-12T21:00:00+03:00"),
 		},
 		{
 			name: "date only",
@@ -99,8 +100,8 @@ func TestParseEventDates(t *testing.T) {
 					Date: "2024-06-13",
 				},
 			},
-			expectedStart: "2024-06-12",
-			expectedEnd:   "2024-06-13",
+			expectedStart: parseDateNoError("2024-06-12"),
+			expectedEnd:   parseDateNoError("2024-06-13"),
 		},
 	}
 	for _, test := range tests {
@@ -111,4 +112,14 @@ func TestParseEventDates(t *testing.T) {
 			assert.Equal(t, test.expectedEnd, actualEnd)
 		})
 	}
+}
+
+func parseTimeNoError(timeString string) time.Time {
+	t, _ := time.Parse(time.RFC3339, timeString)
+	return t
+}
+
+func parseDateNoError(dateString string) time.Time {
+	t, _ := time.Parse(time.DateOnly, dateString)
+	return t
 }

--- a/engine.go
+++ b/engine.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"context"
-	"github.com/pkg/errors"
 	"time"
+
+	"github.com/pkg/errors"
+
+	log "github.com/sirupsen/logrus"
 )
 
 type Engine struct {
@@ -29,6 +32,12 @@ func (e *Engine) Work(ctx context.Context) error {
 
 	for _, event := range events {
 		if event.Creator == e.cfg.CalendarId {
+			log.Info("ignoring event created by calendar owner")
+			continue
+		}
+
+		if event.Start.Before(timeCheck) {
+			log.Info("ignoring outdated event")
 			continue
 		}
 

--- a/engine_test.go
+++ b/engine_test.go
@@ -72,16 +72,18 @@ func (s *EngineSuite) TestReceiveEvents() {
 	ctx := context.Background()
 	lastChecked := time.Now().Add(-time.Minute)
 	s.Require().NoError(s.lastChkdDao.SetLastChecked(lastChecked))
+	start := time.Now().Add(24 * time.Hour)
+	end := start.Add(time.Hour)
 	notifiedEvent := CalendarEvent{
 		Title:   "Should be notified",
-		Start:   "start",
-		End:     "end",
+		Start:   start,
+		End:     end,
 		Creator: "someone else",
 	}
 	ignoredEvent := CalendarEvent{
 		Title:   "Should be ignored",
-		Start:   "start",
-		End:     "end",
+		Start:   start,
+		End:     end,
 		Creator: s.calendarId,
 	}
 	s.calSvcMock.On("GetRecentEvents", ctx, mock.Anything).Return([]CalendarEvent{
@@ -103,20 +105,23 @@ func (s *EngineSuite) TestReceiveEvents() {
 }
 
 func (s *EngineSuite) TestIgnoreEvents() {
+	start := time.Now().Add(24 * time.Hour)
+	end := start.Add(time.Hour)
+
 	tests := []struct {
 		name  string
 		event CalendarEvent
 	}{
 		{"ignore configured calendar id", CalendarEvent{
 			Title:   "Should be ignored",
-			Start:   "start",
-			End:     "end",
+			Start:   start,
+			End:     end,
 			Creator: s.calendarId,
 		}},
 		{"ignore outdated events", CalendarEvent{
 			Title:   "Should be ignored",
-			Start:   time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
-			End:     time.Now().Add(-23 * time.Hour).Format(time.RFC3339),
+			Start:   time.Now().Add(-24 * time.Hour),
+			End:     time.Now().Add(-23 * time.Hour),
 			Creator: "some-other-calendar-id",
 		}},
 	}

--- a/telegram.go
+++ b/telegram.go
@@ -2,8 +2,20 @@ package main
 
 import (
 	"fmt"
+	"time"
+
 	tgbotapi "github.com/go-telegram-bot-api/telegram-bot-api/v5"
 )
+
+var weekdayDict = map[time.Weekday]string{
+	time.Sunday:    "ראשון",
+	time.Monday:    "שני",
+	time.Tuesday:   "שלישי",
+	time.Wednesday: "רביעי",
+	time.Thursday:  "חמישי",
+	time.Friday:    "שישי",
+	time.Saturday:  "שבת",
+}
 
 type Telegram interface {
 	Init() error
@@ -46,12 +58,36 @@ func (t *telegram) NotifyEvent(event CalendarEvent) error {
 func prepareMessageBody(event CalendarEvent) (string, error) {
 	switch event.Status {
 	case StatusCreated:
-		return fmt.Sprintf("🗓️ *%s*\n\n*התחלה:* %s\n*סיום:* %s", event.Title, event.Start, event.End), nil
+		return fmt.Sprintf(
+			"🗓️ *%s*\n\n*התחלה:* %s\n*סיום:* %s",
+			event.Title,
+			FormatDateTime(event.Start),
+			FormatDateTime(event.End)), nil
 	case StatusUpdated:
-		return fmt.Sprintf("️✍🏻 *עדכון: %s*\n\n*התחלה:* %s\n*סיום:* %s", event.Title, event.Start, event.End), nil
+		return fmt.Sprintf(
+			"️✍🏻 *עדכון: %s*\n\n*התחלה:* %s\n*סיום:* %s",
+			event.Title,
+			FormatDateTime(event.Start),
+			FormatDateTime(event.End)), nil
 	case StatusCanceled:
-		return fmt.Sprintf("️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s", event.Title, event.Start, event.End), nil
+		return fmt.Sprintf(
+			"️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s",
+			event.Title,
+			FormatDateTime(event.Start),
+			FormatDateTime(event.End)), nil
 	default:
 		return "", fmt.Errorf("unexpected status: %d", event.Status)
 	}
+}
+
+func FormatDateTime(t time.Time) string {
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
+		return t.Format(time.DateOnly)
+	}
+
+	return fmt.Sprintf("%s (%s)", t.Format(time.DateTime), getDayOfWeek(t))
+}
+
+func getDayOfWeek(t time.Time) string {
+	return weekdayDict[t.Weekday()]
 }

--- a/telegram.go
+++ b/telegram.go
@@ -81,8 +81,8 @@ func prepareMessageBody(event CalendarEvent) (string, error) {
 }
 
 func FormatDateTime(t time.Time) string {
-	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 && t.Nanosecond() == 0 {
-		return t.Format(time.DateOnly)
+	if t.Hour() == 0 && t.Minute() == 0 && t.Second() == 0 {
+		return fmt.Sprintf("%s (%s)", t.Format(time.DateOnly), getDayOfWeek(t))
 	}
 
 	return fmt.Sprintf("%s (%s)", t.Format(time.DateTime), getDayOfWeek(t))

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -21,17 +21,17 @@ func TestPrepareMessageBody(t *testing.T) {
 		{
 			name:     "newly created event",
 			status:   StatusCreated,
-			expected: fmt.Sprintf("🗓️ *%s*\n\n*התחלה:* %s\n*סיום:* %s", title, start, end),
+			expected: fmt.Sprintf("🗓️ *%s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(start), FormatDateTime(end)),
 		},
 		{
 			name:     "updated event",
 			status:   StatusUpdated,
-			expected: fmt.Sprintf("️✍🏻 *עדכון: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, start, end),
+			expected: fmt.Sprintf("️✍🏻 *עדכון: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(start), FormatDateTime(end)),
 		},
 		{
 			name:     "cancelled event",
 			status:   StatusCanceled,
-			expected: fmt.Sprintf("️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, start, end),
+			expected: fmt.Sprintf("️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(start), FormatDateTime(end)),
 		},
 	}
 	for _, test := range tests {

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -20,7 +20,7 @@ func TestPrepareMessageBodyDateTime(t *testing.T) {
 	start := time.Now().Add(24 * time.Hour)
 	end := start.Add(time.Hour)
 
-	testsDateTime := []testCase{
+	tests := []testCase{
 		{
 			name:     "newly created event",
 			status:   StatusCreated,
@@ -38,7 +38,7 @@ func TestPrepareMessageBodyDateTime(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsDateTime {
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			event := CalendarEvent{
 				Title:  title,
@@ -61,7 +61,7 @@ func TestPrepareMessageBodyDateOnly(t *testing.T) {
 	startDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
 	endDay := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
 
-	testsDateOnly := []testCase{
+	tests := []testCase{
 		{
 			name:     "newly created event",
 			status:   StatusCreated,
@@ -79,7 +79,7 @@ func TestPrepareMessageBodyDateOnly(t *testing.T) {
 		},
 	}
 
-	for _, test := range testsDateOnly {
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			event := CalendarEvent{
 				Title:  title,

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -2,15 +2,17 @@ package main
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestPrepareMessageBody(t *testing.T) {
 	title := "some title"
-	start := "start time"
-	end := "end time"
+	start := time.Now().Add(24 * time.Hour)
+	end := start.Add(time.Hour)
 	tests := []struct {
 		name     string
 		status   EventStatus

--- a/telegram_test.go
+++ b/telegram_test.go
@@ -9,15 +9,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestPrepareMessageBody(t *testing.T) {
+type testCase struct {
+	name     string
+	status   EventStatus
+	expected string
+}
+
+func TestPrepareMessageBodyDateTime(t *testing.T) {
 	title := "some title"
 	start := time.Now().Add(24 * time.Hour)
 	end := start.Add(time.Hour)
-	tests := []struct {
-		name     string
-		status   EventStatus
-		expected string
-	}{
+
+	testsDateTime := []testCase{
 		{
 			name:     "newly created event",
 			status:   StatusCreated,
@@ -34,12 +37,54 @@ func TestPrepareMessageBody(t *testing.T) {
 			expected: fmt.Sprintf("️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(start), FormatDateTime(end)),
 		},
 	}
-	for _, test := range tests {
+
+	for _, test := range testsDateTime {
 		t.Run(test.name, func(t *testing.T) {
 			event := CalendarEvent{
 				Title:  title,
 				Start:  start,
 				End:    end,
+				Status: test.status,
+			}
+			actual, err := prepareMessageBody(event)
+			require.NoError(t, err)
+			assert.Equal(t, test.expected, actual)
+		})
+	}
+}
+
+func TestPrepareMessageBodyDateOnly(t *testing.T) {
+	title := "some title"
+	start := time.Now().Add(24 * time.Hour)
+	end := start.Add(time.Hour)
+
+	startDay := time.Date(start.Year(), start.Month(), start.Day(), 0, 0, 0, 0, start.Location())
+	endDay := time.Date(end.Year(), end.Month(), end.Day(), 0, 0, 0, 0, end.Location())
+
+	testsDateOnly := []testCase{
+		{
+			name:     "newly created event",
+			status:   StatusCreated,
+			expected: fmt.Sprintf("🗓️ *%s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(startDay), FormatDateTime(endDay)),
+		},
+		{
+			name:     "updated event",
+			status:   StatusUpdated,
+			expected: fmt.Sprintf("️✍🏻 *עדכון: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(startDay), FormatDateTime(endDay)),
+		},
+		{
+			name:     "cancelled event",
+			status:   StatusCanceled,
+			expected: fmt.Sprintf("️🆇 *בוטל: %s*\n\n*התחלה:* %s\n*סיום:* %s", title, FormatDateTime(startDay), FormatDateTime(endDay)),
+		},
+	}
+
+	for _, test := range testsDateOnly {
+		t.Run(test.name, func(t *testing.T) {
+			event := CalendarEvent{
+				Title:  title,
+				Start:  startDay,
+				End:    endDay,
 				Status: test.status,
 			}
 			actual, err := prepareMessageBody(event)


### PR DESCRIPTION
Google API sometimes sends outdated events, i.e. events that their start time is in the past. This is annoying and leads to confusion.

This PR adds time parsing abilities to the service, parses the start and end times and ignores events that their start time is in the past.

In addition, since the times are now parsed, the notification message structure is also improved with the day of the week.