### PR TITLE
[Bug] Fix end of range for full day events

### DIFF
--- a/cal_service_test.go
+++ b/cal_service_test.go
@@ -101,7 +101,7 @@ func TestParseEventDates(t *testing.T) {
 				},
 			},
 			expectedStart: parseDateNoError("2024-06-12"),
-			expectedEnd:   parseDateNoError("2024-06-13"),
+			expectedEnd:   parseDateNoError("2024-06-12"),
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
I noticed that full day events are reported with an extra day in range. This is a result of the way google calendar reports full day events.

This PR fixes this behavior.